### PR TITLE
[feat] 새 프로젝트 생성 api 구현

### DIFF
--- a/src/main/java/org/umc/peerre/domain/project/constant/Status.java
+++ b/src/main/java/org/umc/peerre/domain/project/constant/Status.java
@@ -1,0 +1,6 @@
+package org.umc.peerre.domain.project.constant;
+
+
+public enum Status {
+    진행중, 종료
+}

--- a/src/main/java/org/umc/peerre/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/umc/peerre/domain/project/controller/ProjectController.java
@@ -1,11 +1,25 @@
 package org.umc.peerre.domain.project.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.umc.peerre.domain.project.dto.request.CreateProjectRequestDto;
+import org.umc.peerre.domain.project.service.ProjectService;
+import org.umc.peerre.global.common.SuccessResponse;
+import org.umc.peerre.global.config.auth.UserId;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/project")
 @RestController
 public class ProjectController {
+
+    private final ProjectService projectService;
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> createProject(@RequestBody CreateProjectRequestDto createProjectRequestDto) {
+        final CreateProjectRequestDto newProject = projectService.createProject(createProjectRequestDto);
+        return SuccessResponse.created(newProject);
+    }
 }

--- a/src/main/java/org/umc/peerre/domain/project/dto/request/CreateProjectRequestDto.java
+++ b/src/main/java/org/umc/peerre/domain/project/dto/request/CreateProjectRequestDto.java
@@ -1,0 +1,11 @@
+package org.umc.peerre.domain.project.dto.request;
+
+import java.time.LocalDateTime;
+
+public record CreateProjectRequestDto(
+        Long teamId,
+        String title
+
+) {
+
+}

--- a/src/main/java/org/umc/peerre/domain/project/entity/Project.java
+++ b/src/main/java/org/umc/peerre/domain/project/entity/Project.java
@@ -5,10 +5,11 @@ import lombok.*;
 import org.umc.peerre.domain.feedback.entity.Comment;
 import org.umc.peerre.domain.feedback.entity.FeedbackAggregation;
 import org.umc.peerre.domain.feedback.entity.FeedbackRegistration;
+import org.umc.peerre.domain.project.constant.Status;
 import org.umc.peerre.domain.teamspace.entity.Teamspace;
 import org.umc.peerre.global.common.BaseTimeEntity;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,14 +32,15 @@ public class Project extends BaseTimeEntity {
     @Column
     private Integer size;
 
+    @Enumerated(EnumType.STRING)
     @Column
-    private Boolean status;
+    private Status status;
 
-    @Column
-    private LocalDateTime start_day;
+    @Column(name="start_day")
+    private LocalDate startDay;
 
-    @Column
-    private LocalDateTime end_day;
+    @Column(name="end_day")
+    private LocalDate endDay;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="team_id", referencedColumnName = "id")
@@ -52,4 +54,7 @@ public class Project extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL)
     private List<Comment> commentList = new ArrayList<>();
+
+
+
 }

--- a/src/main/java/org/umc/peerre/domain/project/service/ProjectService.java
+++ b/src/main/java/org/umc/peerre/domain/project/service/ProjectService.java
@@ -29,6 +29,7 @@ public class ProjectService {
         int size = teamspace.getSize();
 
         Project project = Project.builder()
+                .teamspace(teamspace)
                 .title(title)
                 .status(Status.진행중)
                 .startDay(LocalDate.now())

--- a/src/main/java/org/umc/peerre/domain/project/service/ProjectService.java
+++ b/src/main/java/org/umc/peerre/domain/project/service/ProjectService.java
@@ -3,9 +3,43 @@ package org.umc.peerre.domain.project.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.umc.peerre.domain.project.dto.request.CreateProjectRequestDto;
+import org.umc.peerre.domain.project.constant.Status;
+import org.umc.peerre.domain.project.entity.Project;
+import org.umc.peerre.domain.project.repository.ProjectRepository;
+import org.umc.peerre.domain.teamspace.entity.Teamspace;
+import org.umc.peerre.domain.teamspace.repository.TeamspaceRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
 @Transactional
 public class ProjectService {
+
+    private final TeamspaceRepository teamspaceRepository;
+    private final ProjectRepository projectRepository;
+    public CreateProjectRequestDto createProject(CreateProjectRequestDto createProjectRequestDto) {
+        Long teamId = createProjectRequestDto.teamId();
+        String title = createProjectRequestDto.title();
+
+        Teamspace teamspace = teamspaceRepository.findById(teamId).orElseThrow(()
+                -> new IllegalArgumentException("존재하지 않는 팀입니다."));
+        int size = teamspace.getSize();
+
+        Project project = Project.builder()
+                .title(title)
+                .status(Status.진행중)
+                .startDay(LocalDate.now())
+                .endDay(null)
+                .size(size)
+                .build();
+
+        projectRepository.save(project);
+
+        return null;
+    }
+
+
 }


### PR DESCRIPTION
## Related Issue ✨️

- close : #9

## Summary ✨️

- 프로젝트 생성 API 구현
- 프로젝트 엔티티 필드명 자바 컨벤션에 따라 스네이크 케이스 -> 카멜케이스로 변경
- 프로젝트 엔티티 status 타입 enum으로 변경 (Boolean보다 진행중, 종료으로 보내는게 나을 거 같아서 enum타입으로 바꿨습니다.)
- 프로젝트 엔티티 startDay, endDay 타입 LocalDateTime에서 LocalDate로 변경

## Before i request PR review ✨️


<img width="600" alt="스크린샷 2024-02-07 오전 4 04 22" src="https://github.com/PEER-Re/PEERRE-SERVER/assets/102026726/025fec2d-8948-408c-b9b8-ed2f5ec94c8c">
