### PR TITLE
[feat] 프로젝트 종료 철회 API 구현 & 결과 리포트 조회 API 구현

### DIFF
--- a/src/main/java/org/umc/peerre/domain/feedback/entity/Feedback.java
+++ b/src/main/java/org/umc/peerre/domain/feedback/entity/Feedback.java
@@ -17,11 +17,11 @@ public class Feedback  extends BaseTimeEntity {
     @Id
     private Long id;
 
-    @Column
-    private String feedback_content;
+    @Column(name="feedback_content")
+    private String feedbackContent;
 
-    @Column
-    private Boolean feedback_type;
+    @Column(name="feedback_type")
+    private Boolean feedbackType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="feedbackregistration_id", referencedColumnName = "id")

--- a/src/main/java/org/umc/peerre/domain/feedback/entity/FeedbackAggregation.java
+++ b/src/main/java/org/umc/peerre/domain/feedback/entity/FeedbackAggregation.java
@@ -19,11 +19,11 @@ public class FeedbackAggregation extends BaseTimeEntity {
     @Id
     private Long id;
 
-    @Column
-    private Integer yes_feedback_count;
+    @Column(name="yes_feedback_count")
+    private Integer yesFeedbackCount;
 
-    @Column
-    private Boolean evaluation_status;
+    @Column(name="evaluation_status")
+    private Boolean evaluationStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", referencedColumnName = "id")

--- a/src/main/java/org/umc/peerre/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/org/umc/peerre/domain/feedback/service/FeedbackService.java
@@ -38,7 +38,7 @@ public class FeedbackService {
         User teamMember = userRepository.findById(teamMemberId).orElseThrow(() -> new EntityNotFoundException("해당하는 팀원이 없습니다."));
         Project project = projectRepository.findById(projectId).orElseThrow(() -> new EntityNotFoundException("해당하는 프로젝트가 없습니다."));
 
-        if(!feedbackRegistrationRepository.existsByRecipientIdAndUserAndProject(teamMemberId, user, project)) {
+        if (!feedbackRegistrationRepository.existsByRecipientIdAndUserAndProject(teamMemberId, user, project)) {
 
             FeedbackRegistration feedbackRegistration = FeedbackRegistration.builder()
                     .recipientId(teamMemberId)
@@ -56,8 +56,8 @@ public class FeedbackService {
 
                 if (request.getCommunication() != null) {
                     Feedback feedback = Feedback.builder()
-                            .feedback_content(request.getCommunication() ? "연락이 잘 돼요" : "연락이 안 돼요")
-                            .feedback_type(request.getCommunication())
+                            .feedbackContent(request.getCommunication() ? "연락이 잘 돼요" : "연락이 안 돼요")
+                            .feedbackType(request.getCommunication())
                             .feedbackRegistration(feedbackRegistration)
                             .build();
                     feedbackList.add(feedback);
@@ -65,8 +65,8 @@ public class FeedbackService {
 
                 if (request.getPunctual() != null) {
                     Feedback feedback = Feedback.builder()
-                            .feedback_content(request.getPunctual() ? "시간약속을 잘 지켜요" : "시간약속을 잘 안지켜요")
-                            .feedback_type(request.getPunctual())
+                            .feedbackContent(request.getPunctual() ? "시간약속을 잘 지켜요" : "시간약속을 잘 안지켜요")
+                            .feedbackType(request.getPunctual())
                             .feedbackRegistration(feedbackRegistration)
                             .build();
                     feedbackList.add(feedback);
@@ -74,8 +74,8 @@ public class FeedbackService {
 
                 if (request.getCompetent() != null) {
                     Feedback feedback = Feedback.builder()
-                            .feedback_content(request.getCompetent() ? "능력이 뛰어나요" : "능력이 뒤떨어져요")
-                            .feedback_type(request.getCompetent())
+                            .feedbackContent(request.getCompetent() ? "능력이 뛰어나요" : "능력이 뒤떨어져요")
+                            .feedbackType(request.getCompetent())
                             .feedbackRegistration(feedbackRegistration)
                             .build();
                     feedbackList.add(feedback);
@@ -83,8 +83,8 @@ public class FeedbackService {
 
                 if (request.getArticulate() != null) {
                     Feedback feedback = Feedback.builder()
-                            .feedback_content(request.getArticulate() ? "말을 조리있게 잘해요" : "말을 조리있게 못해요")
-                            .feedback_type(request.getArticulate())
+                            .feedbackContent(request.getArticulate() ? "말을 조리있게 잘해요" : "말을 조리있게 못해요")
+                            .feedbackType(request.getArticulate())
                             .feedbackRegistration(feedbackRegistration)
                             .build();
                     feedbackList.add(feedback);
@@ -92,8 +92,8 @@ public class FeedbackService {
 
                 if (request.getThorough() != null) {
                     Feedback feedback = Feedback.builder()
-                            .feedback_content(request.getThorough() ? "빈틈이 없어요" : "빈틈이 있어요")
-                            .feedback_type(request.getThorough())
+                            .feedbackContent(request.getThorough() ? "빈틈이 없어요" : "빈틈이 있어요")
+                            .feedbackType(request.getThorough())
                             .feedbackRegistration(feedbackRegistration)
                             .build();
                     feedbackList.add(feedback);
@@ -101,8 +101,8 @@ public class FeedbackService {
 
                 if (request.getEngaging() != null) {
                     Feedback feedback = Feedback.builder()
-                            .feedback_content(request.getEngaging() ? "재미있어요" : "재미없어요")
-                            .feedback_type(request.getEngaging())
+                            .feedbackContent(request.getEngaging() ? "재미있어요" : "재미없어요")
+                            .feedbackType(request.getEngaging())
                             .feedbackRegistration(feedbackRegistration)
                             .build();
                     feedbackList.add(feedback);
@@ -113,86 +113,82 @@ public class FeedbackService {
 
             feedbackRegistrationRepository.save(feedbackRegistration);
 
-            if (feedbackAggregation.getEvaluation_status() == null) {
-                feedbackAggregation.setEvaluation_status(false);
+            if (feedbackAggregation.getEvaluationStatus() == null) {
+                feedbackAggregation.setEvaluationStatus(false);
             }
 
-            if (!feedbackAggregation.getEvaluation_status()) {
-                feedbackAggregation.setEvaluation_status(true);
+            if (!feedbackAggregation.getEvaluationStatus()) {
+                feedbackAggregation.setEvaluationStatus(true);
             }
             feedbackAggregationRepository.save(feedbackAggregation);
-        }
-
-        else {
+        } else {
             FeedbackRegistration feedbackRegistration = feedbackRegistrationRepository.findByRecipientIdAndUserAndProject(teamMemberId, user, project);
 
             List<Feedback> feedbackList = feedbackRegistration.getFeedbackList();
 
-            feedbackList
-                    .forEach(feedback -> {
-                        if((feedback.getFeedback_content().equals("연락이 잘 돼요") || feedback.getFeedback_content().equals("연락이 안 돼요")) && request.getCommunication()==null) {
-                            feedback.setFeedback_type(null);
-                        } else if((feedback.getFeedback_content().equals("연락이 잘 돼요") || feedback.getFeedback_content().equals("연락이 안 돼요")) && request.getCommunication()) {
-                            feedback.setFeedback_content("연락이 잘 돼요");
-                            feedback.setFeedback_type(true);
-                        } else if((feedback.getFeedback_content().equals("연락이 잘 돼요") || feedback.getFeedback_content().equals("연락이 안 돼요")) && request.getCommunication()==false) {
-                            feedback.setFeedback_content("연락이 안 돼요");
-                            feedback.setFeedback_type(false);
-                        }
+            feedbackList.forEach(feedback -> {
+                if ((feedback.getFeedbackContent().equals("연락이 잘 돼요") || feedback.getFeedbackContent().equals("연락이 안 돼요")) && request.getCommunication() == null) {
+                    feedback.setFeedbackType(null);
+                } else if ((feedback.getFeedbackContent().equals("연락이 잘 돼요") || feedback.getFeedbackContent().equals("연락이 안 돼요")) && request.getCommunication()) {
+                    feedback.setFeedbackContent("연락이 잘 돼요");
+                    feedback.setFeedbackType(true);
+                } else if ((feedback.getFeedbackContent().equals("연락이 잘 돼요") || feedback.getFeedbackContent().equals("연락이 안 돼요")) && request.getCommunication() == false) {
+                    feedback.setFeedbackContent("연락이 안 돼요");
+                    feedback.setFeedbackType(false);
+                }
 
-                        if ((feedback.getFeedback_content().equals("시간약속을 잘 지켜요") || feedback.getFeedback_content().equals("시간약속을 잘 안지켜요")) && request.getPunctual()==null) {
-                            feedback.setFeedback_type(null);
-                        } else if((feedback.getFeedback_content().equals("시간약속을 잘 지켜요") || feedback.getFeedback_content().equals("시간약속을 잘 안지켜요")) && request.getPunctual()) {
-                            feedback.setFeedback_content("시간약속을 잘 지켜요");
-                            feedback.setFeedback_type(true);
-                        } else if((feedback.getFeedback_content().equals("시간약속을 잘 지켜요") || feedback.getFeedback_content().equals("시간약속을 잘 안지켜요")) && request.getPunctual()==false) {
-                            feedback.setFeedback_content("시간약속을 잘 안지켜요");
-                            feedback.setFeedback_type(false);
-                        }
+                if ((feedback.getFeedbackContent().equals("시간약속을 잘 지켜요") || feedback.getFeedbackContent().equals("시간약속을 잘 안지켜요")) && request.getPunctual() == null) {
+                    feedback.setFeedbackType(null);
+                } else if ((feedback.getFeedbackContent().equals("시간약속을 잘 지켜요") || feedback.getFeedbackContent().equals("시간약속을 잘 안지켜요")) && request.getPunctual()) {
+                    feedback.setFeedbackContent("시간약속을 잘 지켜요");
+                    feedback.setFeedbackType(true);
+                } else if ((feedback.getFeedbackContent().equals("시간약속을 잘 지켜요") || feedback.getFeedbackContent().equals("시간약속을 잘 안지켜요")) && request.getPunctual() == false) {
+                    feedback.setFeedbackContent("시간약속을 잘 안지켜요");
+                    feedback.setFeedbackType(false);
+                }
 
-                        if ((feedback.getFeedback_content().equals("능력이 뛰어나요") || feedback.getFeedback_content().equals("능력이 뒤떨어져요")) && request.getCompetent()==null) {
-                            feedback.setFeedback_type(null);
-                        } else if((feedback.getFeedback_content().equals("능력이 뛰어나요") || feedback.getFeedback_content().equals("능력이 뒤떨어져요")) && request.getCompetent()) {
-                            feedback.setFeedback_content("능력이 뛰어나요");
-                            feedback.setFeedback_type(true);
-                        } else if((feedback.getFeedback_content().equals("능력이 뛰어나요") || feedback.getFeedback_content().equals("능력이 뒤떨어져요")) && request.getCompetent()==false)  {
-                            feedback.setFeedback_content("능력이 뒤떨어져요");
-                            feedback.setFeedback_type(false);
-                        }
+                if ((feedback.getFeedbackContent().equals("능력이 뛰어나요") || feedback.getFeedbackContent().equals("능력이 뒤떨어져요")) && request.getCompetent() == null) {
+                    feedback.setFeedbackType(null);
+                } else if ((feedback.getFeedbackContent().equals("능력이 뛰어나요") || feedback.getFeedbackContent().equals("능력이 뒤떨어져요")) && request.getCompetent()) {
+                    feedback.setFeedbackContent("능력이 뛰어나요");
+                    feedback.setFeedbackType(true);
+                } else if ((feedback.getFeedbackContent().equals("능력이 뛰어나요") || feedback.getFeedbackContent().equals("능력이 뒤떨어져요")) && request.getCompetent() == false) {
+                    feedback.setFeedbackContent("능력이 뒤떨어져요");
+                    feedback.setFeedbackType(false);
+                }
 
-                        if((feedback.getFeedback_content().equals("말을 조리있게 잘해요")|| feedback.getFeedback_content().equals("말을 조리있게 못해요")) && request.getArticulate()==null) {
-                            feedback.setFeedback_type(null);
-                        } else if((feedback.getFeedback_content().equals("말을 조리있게 잘해요") || feedback.getFeedback_content().equals("말을 조리있게 못해요")) && request.getArticulate()) {
-                            feedback.setFeedback_content("말을 조리있게 잘해요");
-                            feedback.setFeedback_type(true);
-                        } else if((feedback.getFeedback_content().equals("말을 조리있게 잘해요")|| feedback.getFeedback_content().equals("말을 조리있게 못해요")) && request.getArticulate()==false){
-                            feedback.setFeedback_content("말을 조리있게 못해요");
-                            feedback.setFeedback_type(false);
-                        }
+                if ((feedback.getFeedbackContent().equals("말을 조리있게 잘해요") || feedback.getFeedbackContent().equals("말을 조리있게 못해요")) && request.getArticulate() == null) {
+                    feedback.setFeedbackType(null);
+                } else if ((feedback.getFeedbackContent().equals("말을 조리있게 잘해요") || feedback.getFeedbackContent().equals("말을 조리있게 못해요")) && request.getArticulate()) {
+                    feedback.setFeedbackContent("말을 조리있게 잘해요");
+                    feedback.setFeedbackType(true);
+                } else if ((feedback.getFeedbackContent().equals("말을 조리있게 잘해요") || feedback.getFeedbackContent().equals("말을 조리있게 못해요")) && request.getArticulate() == false) {
+                    feedback.setFeedbackContent("말을 조리있게 못해요");
+                    feedback.setFeedbackType(false);
+                }
 
-                        if((feedback.getFeedback_content().equals("빈틈이 없어요") || feedback.getFeedback_content().equals("빈틈이 있어요")) && request.getThorough()==null) {
-                            feedback.setFeedback_type(null);
-                        } else if((feedback.getFeedback_content().equals("빈틈이 없어요") || feedback.getFeedback_content().equals("빈틈이 있어요")) && request.getThorough()) {
-                            feedback.setFeedback_content("빈틈이 없어요");
-                            feedback.setFeedback_type(true);
-                        } else if((feedback.getFeedback_content().equals("빈틈이 없어요") || feedback.getFeedback_content().equals("빈틈이 있어요")) && request.getThorough()==false) {
-                            feedback.setFeedback_content("빈틈이 있어요");
-                            feedback.setFeedback_type(false);
-                        }
+                if ((feedback.getFeedbackContent().equals("빈틈이 없어요") || feedback.getFeedbackContent().equals("빈틈이 있어요")) && request.getThorough() == null) {
+                    feedback.setFeedbackType(null);
+                } else if ((feedback.getFeedbackContent().equals("빈틈이 없어요") || feedback.getFeedbackContent().equals("빈틈이 있어요")) && request.getThorough()) {
+                    feedback.setFeedbackContent("빈틈이 없어요");
+                    feedback.setFeedbackType(true);
+                } else if ((feedback.getFeedbackContent().equals("빈틈이 없어요") || feedback.getFeedbackContent().equals("빈틈이 있어요")) && request.getThorough() == false) {
+                    feedback.setFeedbackContent("빈틈이 있어요");
+                    feedback.setFeedbackType(false);
+                }
 
-                        if((feedback.getFeedback_content().equals("재미있어요") ||feedback.getFeedback_content().equals("재미없어요")) && request.getEngaging()==null) {
-                            feedback.setFeedback_type(null);
-                        } else if((feedback.getFeedback_content().equals("재미있어요") || feedback.getFeedback_content().equals("재미없어요")) && request.getEngaging()) {
-                            feedback.setFeedback_content("재미있어요");
-                            feedback.setFeedback_type(true);
-                        }  else if((feedback.getFeedback_content().equals("재미있어요") ||feedback.getFeedback_content().equals("재미없어요")) && request.getEngaging()==false)  {
-                            feedback.setFeedback_content("재미없어요");
-                            feedback.setFeedback_type(false);
-                        }
-                    });
+                if ((feedback.getFeedbackContent().equals("재미있어요") || feedback.getFeedbackContent().equals("재미없어요")) && request.getEngaging() == null) {
+                    feedback.setFeedbackType(null);
+                } else if ((feedback.getFeedbackContent().equals("재미있어요") || feedback.getFeedbackContent().equals("재미없어요")) && request.getEngaging()) {
+                    feedback.setFeedbackContent("재미있어요");
+                    feedback.setFeedbackType(true);
+                } else if ((feedback.getFeedbackContent().equals("재미있어요") || feedback.getFeedbackContent().equals("재미없어요")) && request.getEngaging() == false) {
+                    feedback.setFeedbackContent("재미없어요");
+                    feedback.setFeedbackType(false);
+                }
+            });
             feedbackRepository.saveAll(feedbackList);
             feedbackRegistrationRepository.save(feedbackRegistration);
-
         }
         return "피드백 등록(수정) 성공";
     }

--- a/src/main/java/org/umc/peerre/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/umc/peerre/domain/project/controller/ProjectController.java
@@ -5,9 +5,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.umc.peerre.domain.project.dto.request.CreateProjectRequestDto;
 import org.umc.peerre.domain.project.dto.response.CreateProjectResponseDto;
+import org.umc.peerre.domain.project.dto.response.MyFeedbackResponseDto;
 import org.umc.peerre.domain.project.dto.response.TeamInfoResponseDto;
 import org.umc.peerre.domain.project.service.ProjectService;
 import org.umc.peerre.global.common.SuccessResponse;
+import org.umc.peerre.global.config.auth.UserId;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/project")
@@ -34,9 +38,15 @@ public class ProjectController {
         return SuccessResponse.ok(null);
     }
 
-    @GetMapping("/{projectId}/team-info")
+    @GetMapping("/{projectId}/project-info")
     public ResponseEntity<SuccessResponse<?>> getTeamInfo(@PathVariable Long projectId) {
         final TeamInfoResponseDto teamInfoResponseDto = projectService.getTeamInfo(projectId);
         return SuccessResponse.ok(teamInfoResponseDto);
+    }
+
+    @GetMapping("/{projectId}/my-feedback")
+    public ResponseEntity<SuccessResponse<?>> getMyFeedback(@UserId Long userId, @PathVariable Long projectId) {
+        final MyFeedbackResponseDto myFeedbackResponseDto = projectService.getMyFeedback(userId, projectId);
+        return SuccessResponse.ok(myFeedbackResponseDto);
     }
 }

--- a/src/main/java/org/umc/peerre/domain/project/controller/ProjectController.java
+++ b/src/main/java/org/umc/peerre/domain/project/controller/ProjectController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.umc.peerre.domain.project.dto.request.CreateProjectRequestDto;
 import org.umc.peerre.domain.project.dto.response.CreateProjectResponseDto;
+import org.umc.peerre.domain.project.dto.response.TeamInfoResponseDto;
 import org.umc.peerre.domain.project.service.ProjectService;
 import org.umc.peerre.global.common.SuccessResponse;
 
@@ -25,5 +26,17 @@ public class ProjectController {
     public ResponseEntity<SuccessResponse<?>> closeProject(@PathVariable Long projectId) {
         projectService.closeProject(projectId);
         return SuccessResponse.ok(null);
+    }
+
+    @PostMapping("/{projectId}/reopen")
+    public ResponseEntity<SuccessResponse<?>> reopenProject(@PathVariable Long projectId) {
+        projectService.reopenProject(projectId);
+        return SuccessResponse.ok(null);
+    }
+
+    @GetMapping("/{projectId}/team-info")
+    public ResponseEntity<SuccessResponse<?>> getTeamInfo(@PathVariable Long projectId) {
+        final TeamInfoResponseDto teamInfoResponseDto = projectService.getTeamInfo(projectId);
+        return SuccessResponse.ok(teamInfoResponseDto);
     }
 }

--- a/src/main/java/org/umc/peerre/domain/project/dto/response/MyFeedbackResponseDto.java
+++ b/src/main/java/org/umc/peerre/domain/project/dto/response/MyFeedbackResponseDto.java
@@ -1,0 +1,9 @@
+package org.umc.peerre.domain.project.dto.response;
+
+import java.util.List;
+
+public record MyFeedbackResponseDto(
+        List<MyYesFeedbackResponseDto> MyYesFeedback,
+        List<MyNoFeedbackResponseDto> MyNoFeedback
+) {
+}

--- a/src/main/java/org/umc/peerre/domain/project/dto/response/MyNoFeedbackResponseDto.java
+++ b/src/main/java/org/umc/peerre/domain/project/dto/response/MyNoFeedbackResponseDto.java
@@ -1,0 +1,14 @@
+package org.umc.peerre.domain.project.dto.response;
+
+import org.umc.peerre.domain.feedback.entity.Feedback;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record MyNoFeedbackResponseDto(
+        String NofeedbackContent
+) {
+    public static MyNoFeedbackResponseDto of(Feedback feedback) {
+        return new MyNoFeedbackResponseDto(feedback.getFeedbackContent());
+    }
+}

--- a/src/main/java/org/umc/peerre/domain/project/dto/response/MyYesFeedbackResponseDto.java
+++ b/src/main/java/org/umc/peerre/domain/project/dto/response/MyYesFeedbackResponseDto.java
@@ -1,0 +1,15 @@
+package org.umc.peerre.domain.project.dto.response;
+
+import org.umc.peerre.domain.feedback.entity.Feedback;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record MyYesFeedbackResponseDto(
+        String yesFeedbackContent
+) {
+    public static MyYesFeedbackResponseDto of(Feedback feedback) {
+        return new MyYesFeedbackResponseDto(feedback.getFeedbackContent());
+    }
+
+}

--- a/src/main/java/org/umc/peerre/domain/project/dto/response/TeamInfoResponseDto.java
+++ b/src/main/java/org/umc/peerre/domain/project/dto/response/TeamInfoResponseDto.java
@@ -1,0 +1,15 @@
+package org.umc.peerre.domain.project.dto.response;
+
+import java.time.LocalDate;
+
+public record TeamInfoResponseDto(
+        String teamName,
+        LocalDate startDay,
+        LocalDate endDay,
+        int size,
+        double totalParticipateRate,
+        int totalYesFeedbackCount,
+        int totalNoFeedbackCount
+
+) {
+}

--- a/src/main/java/org/umc/peerre/domain/project/repository/ProjectRepository.java
+++ b/src/main/java/org/umc/peerre/domain/project/repository/ProjectRepository.java
@@ -9,4 +9,8 @@ import java.util.Optional;
 
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     Optional<Object> findByTeamspaceAndStatus(Teamspace teamspace, Status status);
+
+    Optional<Object> findByTeamspaceIdAndStatus(Long teamId, Status status);
+
+    Optional<Project> findFirstByTeamspaceIdAndStatusOrderByEndDayDesc(Long teamId, Status status);
 }

--- a/src/main/java/org/umc/peerre/domain/project/service/ProjectService.java
+++ b/src/main/java/org/umc/peerre/domain/project/service/ProjectService.java
@@ -7,8 +7,7 @@ import org.umc.peerre.domain.feedback.entity.FeedbackAggregation;
 import org.umc.peerre.domain.feedback.entity.FeedbackRegistration;
 import org.umc.peerre.domain.project.dto.request.CreateProjectRequestDto;
 import org.umc.peerre.domain.project.constant.Status;
-import org.umc.peerre.domain.project.dto.response.CreateProjectResponseDto;
-import org.umc.peerre.domain.project.dto.response.TeamInfoResponseDto;
+import org.umc.peerre.domain.project.dto.response.*;
 import org.umc.peerre.domain.project.entity.Project;
 import org.umc.peerre.domain.project.repository.ProjectRepository;
 import org.umc.peerre.domain.teamspace.entity.Teamspace;
@@ -18,9 +17,11 @@ import org.umc.peerre.global.error.exception.EntityNotFoundException;
 import org.umc.peerre.global.error.exception.InvalidValueException;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.umc.peerre.global.error.ErrorCode.*;
 
@@ -111,7 +112,7 @@ public class ProjectService {
     private double calculateTotalParticipateRate(List<FeedbackAggregation> feedbackAggregationList) {
         long totalFeedbackCount = feedbackAggregationList.size();
         long evaluatedFeedbackCount = feedbackAggregationList.stream()
-                .filter(feedbackAggregation -> feedbackAggregation.getEvaluation_status())
+                .filter(feedbackAggregation -> feedbackAggregation.getEvaluationStatus())
                 .count();
 
         return totalFeedbackCount > 0 ? (double) evaluatedFeedbackCount / totalFeedbackCount : 0.0;
@@ -120,8 +121,38 @@ public class ProjectService {
     private int calculateTotalFeedbackCount(List<FeedbackRegistration> feedbackRegistrationList, boolean isYes) {
         return (int) feedbackRegistrationList.stream()
                 .flatMap(feedbackRegistration -> feedbackRegistration.getFeedbackList().stream())
-                .filter(feedback -> isYes == feedback.getFeedback_type())
+                .filter(feedback -> isYes == feedback.getFeedbackType())
                 .count();
+    }
+
+
+    public MyFeedbackResponseDto getMyFeedback(Long userId, Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PROJECT_NOT_FOUND));
+
+        List<FeedbackRegistration> feedbackRegistrations = project.getFeedbackRegistrationList().stream()
+                .filter(registration -> registration.getRecipientId().equals(userId))
+                .collect(Collectors.toList());
+
+        if (feedbackRegistrations.isEmpty()) {
+            throw new EntityNotFoundException(FEEDBACK_REGISTRATION_NOT_FOUND);
+        }
+
+        List<MyYesFeedbackResponseDto> yesFeedbackList = feedbackRegistrations.stream()
+                .flatMap(registration -> registration.getFeedbackList().stream()
+                        .filter(feedback -> Boolean.TRUE.equals(feedback.getFeedbackType()))
+                        .map(feedback -> new MyYesFeedbackResponseDto(feedback.getFeedbackContent()))
+                )
+                .collect(Collectors.toList());
+
+        List<MyNoFeedbackResponseDto> noFeedbackList = feedbackRegistrations.stream()
+                .flatMap(registration -> registration.getFeedbackList().stream()
+                        .filter(feedback -> Boolean.FALSE.equals(feedback.getFeedbackType()))
+                        .map(feedback -> new MyNoFeedbackResponseDto(feedback.getFeedbackContent()))
+                )
+                .collect(Collectors.toList());
+
+        return new MyFeedbackResponseDto(yesFeedbackList, noFeedbackList);
     }
 
 

--- a/src/main/java/org/umc/peerre/domain/project/service/ProjectService.java
+++ b/src/main/java/org/umc/peerre/domain/project/service/ProjectService.java
@@ -3,9 +3,12 @@ package org.umc.peerre.domain.project.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.umc.peerre.domain.feedback.entity.FeedbackAggregation;
+import org.umc.peerre.domain.feedback.entity.FeedbackRegistration;
 import org.umc.peerre.domain.project.dto.request.CreateProjectRequestDto;
 import org.umc.peerre.domain.project.constant.Status;
 import org.umc.peerre.domain.project.dto.response.CreateProjectResponseDto;
+import org.umc.peerre.domain.project.dto.response.TeamInfoResponseDto;
 import org.umc.peerre.domain.project.entity.Project;
 import org.umc.peerre.domain.project.repository.ProjectRepository;
 import org.umc.peerre.domain.teamspace.entity.Teamspace;
@@ -16,8 +19,10 @@ import org.umc.peerre.global.error.exception.InvalidValueException;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
-import static org.umc.peerre.global.error.ErrorCode.TEAM_NOT_FOUND;
+import static org.umc.peerre.global.error.ErrorCode.*;
 
 @RequiredArgsConstructor
 @Service
@@ -34,7 +39,7 @@ public class ProjectService {
                 -> new EntityNotFoundException(TEAM_NOT_FOUND));
 
         if (projectRepository.findByTeamspaceAndStatus(teamspace, Status.진행중).isPresent()) {
-            throw new InvalidValueException(ErrorCode.PROJECT_ALREADY_IN_PROGRESS);
+            throw new InvalidValueException(PROJECT_ALREADY_IN_PROGRESS);
         }
 
 
@@ -60,4 +65,65 @@ public class ProjectService {
         project.setStatus(Status.종료);
         project.setEndDay(LocalDate.now());
     }
+
+    public void reopenProject(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PROJECT_NOT_FOUND));
+
+        Long teamId = project.getTeamspace().getId();
+        if (projectRepository.findByTeamspaceIdAndStatus(teamId,Status.진행중).isPresent()) {
+            throw new InvalidValueException(PROJECT_ALREADY_IN_PROGRESS);
+        }
+
+        Optional<Project> latestProject = projectRepository.findFirstByTeamspaceIdAndStatusOrderByEndDayDesc(teamId, Status.종료);
+        System.out.println(latestProject.get().getId());
+        if (latestProject.isEmpty() || !latestProject.get().getId().equals(projectId)) {
+            throw new InvalidValueException(NOT_LASTEST_PROJECT);
+        }
+
+        project.setStatus(Status.진행중);
+        project.setEndDay(null);
+    }
+
+    public TeamInfoResponseDto getTeamInfo(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.PROJECT_NOT_FOUND));
+
+        List<FeedbackAggregation> feedbackAggregationList = project.getFeedbackAggregationList();
+        List<FeedbackRegistration> feedbackRegistrationList = project.getFeedbackRegistrationList();
+
+        double totalParticipateRate = calculateTotalParticipateRate(feedbackAggregationList);
+
+        int totalYesFeedbackCount = calculateTotalFeedbackCount(feedbackRegistrationList, true);
+        int totalNoFeedbackCount = calculateTotalFeedbackCount(feedbackRegistrationList, false);
+
+        return new TeamInfoResponseDto(
+                project.getTeamspace().getName(),
+                project.getStartDay(),
+                project.getEndDay(),
+                project.getSize(),
+                totalParticipateRate * 100.0,
+                totalYesFeedbackCount,
+                totalNoFeedbackCount
+        );
+    }
+
+    private double calculateTotalParticipateRate(List<FeedbackAggregation> feedbackAggregationList) {
+        long totalFeedbackCount = feedbackAggregationList.size();
+        long evaluatedFeedbackCount = feedbackAggregationList.stream()
+                .filter(feedbackAggregation -> feedbackAggregation.getEvaluation_status())
+                .count();
+
+        return totalFeedbackCount > 0 ? (double) evaluatedFeedbackCount / totalFeedbackCount : 0.0;
+    }
+
+    private int calculateTotalFeedbackCount(List<FeedbackRegistration> feedbackRegistrationList, boolean isYes) {
+        return (int) feedbackRegistrationList.stream()
+                .flatMap(feedbackRegistration -> feedbackRegistration.getFeedbackList().stream())
+                .filter(feedback -> isYes == feedback.getFeedback_type())
+                .count();
+    }
+
+
+
 }

--- a/src/main/java/org/umc/peerre/global/error/ErrorCode.java
+++ b/src/main/java/org/umc/peerre/global/error/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
      * 400 Bad Request
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    PROJECT_ALREADY_IN_PROGRESS(HttpStatus.BAD_REQUEST, "이미 진행 중인 프로젝트가 존재합니다."),
+    NOT_LASTEST_PROJECT(HttpStatus.BAD_REQUEST, "최신 프로젝트가 아닙니다."),
 
     /**
      * 401 Unauthorized
@@ -24,7 +26,6 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "리프레시 토큰의 값이 올바르지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
     NOT_MATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "일치하지 않는 리프레시 토큰입니다."),
-    PROJECT_ALREADY_IN_PROGRESS(HttpStatus.BAD_REQUEST, "이미 진행 중인 프로젝트가 존재합니다."),
 
     /**
      * 403 Forbidden

--- a/src/main/java/org/umc/peerre/global/error/ErrorCode.java
+++ b/src/main/java/org/umc/peerre/global/error/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "엔티티를 찾을 수 없습니다."),
     TEAM_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 팀입니다."),
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 프로젝트입니다."),
+    FEEDBACK_REGISTRATION_NOT_FOUND(HttpStatus.NOT_FOUND, "피드백 등록 정보를 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed


### PR DESCRIPTION
## Related Issue ✨️

- close : #13

## Summary ✨️

- 프로젝트 종료 철회 API 구현  
- 결과 리포트 조회 (프로젝트 정보 조회)API 구현
- 결과 리포트 조회 (내가 받은 피드백 조회)API 구현

## Before i request PR review ✨️

- 결과 리포트 디자인 페이지 (내가 받은 피드백 조회)하나 더 생겨서 api새로 만들었습니다.
- 엔티티 필드명 카멜케이스로 변경하였습니다.
